### PR TITLE
Change spike_detector to spike_recorder

### DIFF
--- a/multiarea_model/simulation.py
+++ b/multiarea_model/simulation.py
@@ -170,7 +170,7 @@ class Simulation:
         - spike detector
         - voltmeter
         """
-        self.spike_detector = nest.Create('spike_detector')
+        self.spike_detector = nest.Create('spike_recorder')
         status_dict = deepcopy(self.params['recording_dict']['spike_dict'])
         label = '-'.join((self.label,
                           status_dict['label']))


### PR DESCRIPTION
The name of the spike_detector has changed to spike_recorder in the very recent versions of NEST3.